### PR TITLE
No KeyError when processing auto-cleared watches

### DIFF
--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -65,7 +65,9 @@ class Inotify(object):
         our tracking since inotify already cleans-up the watch.
         """
 
-        wd = self.__watches[path]
+        wd = self.__watches.get(path)
+        if wd is None:
+            return
 
         del self.__watches[path]
         del self.__watches_r[wd]
@@ -131,7 +133,9 @@ class Inotify(object):
 
             self.__buffer = self.__buffer[event_length:]
 
-            path = self.__watches_r[header.wd]
+            path = self.__watches_r.get(header.wd)
+            if path is None:
+                break
             yield (header, type_names, path, filename)
 
             buffer_length = len(self.__buffer)


### PR DESCRIPTION
As discussed in https://github.com/dsoprea/PyInotify/issues/1 , it seems that events are processed out-of-order which can result in KeyErrors being raised when files/directories are removed.
As the KeyErrors are raised inside the event_gen() generator, the calling program cannot handle them gracefully.

There are two cases:
- An event is to be generated for a watch that has already been cleared.
- A watch is to be cleared twice.
This patch should prevent KeyErrors from being raised in these cases by checking if the watches exist.