### PR TITLE
resolves #25, list of binary paths can't be logged with existing call

### DIFF
--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -261,7 +261,7 @@ class InotifyTrees(BaseTree):
         self.__load_trees(paths)
 
     def __load_trees(self, paths):
-        _LOGGER.debug("Adding initial watches on trees: [%s]", ",".join(paths))
+        _LOGGER.debug("Adding initial watches on trees: [%s]", ",".join(map(str, paths)))
 
         q = paths
         while q:


### PR DESCRIPTION
Sorry its such a pathetic little fix, but I was using this library and I got sick of patching it in my conda env :)