### PR TITLE
Remove debug logging.

### DIFF
--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -261,8 +261,6 @@ class InotifyTrees(BaseTree):
         self.__load_trees(paths)
 
     def __load_trees(self, paths):
-        _LOGGER.debug("Adding initial watches on trees: [%s]", ",".join(map(str, paths)))
-
         q = paths
         while q:
             current_path = q[0]


### PR DESCRIPTION
This PR removes the debug logging has been removed in `InotifyTrees.__load_trees()` becuase `join` expects a `str`,