### PR TITLE
Propagate superficial parameter to remove_watch_with_id

### DIFF
--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -115,7 +115,7 @@ class Inotify(object):
 
         del self.__watches[path]
 
-        self.remove_watch_with_id(wd)
+        self.remove_watch_with_id(wd, superficial)
 
     def remove_watch_with_id(self, wd, superficial=False):
         del self.__watches_r[wd]


### PR DESCRIPTION
The remove_watch method takes a superficial parameter but never used
it, which made the remove_watch_with_id function set it as False by default.
This fixes that behavior by propagating the parameter.

Signed-off-by: Raphaël Beamonte <raphael.beamonte@gmail.com>