### PR TITLE
Fix missing errno for library calls

### DIFF
--- a/inotify/calls.py
+++ b/inotify/calls.py
@@ -1,5 +1,6 @@
 import logging
 import ctypes
+import os
 
 import inotify.library
 
@@ -10,8 +11,11 @@ _LIB = inotify.library.instance
 
 class InotifyError(Exception):
     def __init__(self, message, *args, **kwargs):
-        self.errno = ctypes.get_errno()
-        message += " ERRNO=(%d)" % (self.errno,)
+        errnum = ctypes.get_errno()
+        self.errno = errnum
+        try: errmsg = os.strerror(errnum)
+        except ValueError as ex: errmsg = ''
+        message += " ERRNO=%d %s" % (errnum,errmsg)
 
         super(InotifyError, self).__init__(message, *args, **kwargs)
 

--- a/inotify/library.py
+++ b/inotify/library.py
@@ -5,4 +5,4 @@ _FILEPATH = ctypes.util.find_library('c')
 if _FILEPATH is None:
     _FILEPATH = 'libc.so.6'
 
-instance = ctypes.cdll.LoadLibrary(_FILEPATH)
+instance = ctypes.CDLL(_FILEPATH, use_errno=True)

--- a/tests/test_inotify.py
+++ b/tests/test_inotify.py
@@ -2,9 +2,11 @@
 
 import os
 import unittest
+import errno
 
 import inotify.constants
 import inotify.adapters
+import inotify.calls
 import inotify.test_support
 
 try:
@@ -145,6 +147,16 @@ class TestInotify(unittest.TestCase):
 
         self.assertEquals(names, all_names)
 
+    def test__exception_errno(self):
+        with inotify.test_support.temp_path() as path:
+            i = inotify.adapters.Inotify()
+            errnum = None
+            path1 = os.path.join(path, 'abc')
+            try:
+                i.add_watch(path1)
+            except inotify.calls.InotifyError as ex:
+                errnum = ex.errno
+            self.assertEquals(errnum, errno.ENOENT)
 
 class TestInotifyTree(unittest.TestCase):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Fix to enable inotify errno + message in Exceptions resulting from unsuccessfull library calls.