### PR TITLE
Stay Python 2.6 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-
+matrix:
+    include:
+        - os: linux
+          python: 2.6
+          cache: pip
+        - os: linux
+          python: 2.7
+        - os: linux
+          python: 3.3
+        - os: linux
+          python: 3.4
+        - os: linux
+          python: 3.5
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install pycparser==2.18; pip install unittest2; fi
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
   - "3.5"
 
 install:
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install pycparser==2.18; pip install unittest2; fi
   - pip install -r requirements.txt
   - pip install coveralls
 script: nosetests -s -v --with-coverage --cover-package=inotify

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,14 @@ matrix:
           python: 3.4
         - os: linux
           python: 3.5
+        - os: linux
+          python: 3.6
+        - os: linux
+          python: 3.7
+        - os: linux
+          python: 3.8
+        - os: linux
+          python: 3.9
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install pycparser==2.18; pip install unittest2; fi
   - pip install -r requirements.txt

--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -166,7 +166,7 @@ class Inotify(object):
 
             header = _INOTIFY_EVENT(*header_raw)
             type_names = self._get_event_names(header.mask)
-            _LOGGER.debug("Events received in stream: {}".format(type_names))
+            _LOGGER.debug("Events received in stream: {0}".format(type_names))
 
             event_length = (_STRUCT_HEADER_LENGTH + header.len)
             if length < event_length:
@@ -225,7 +225,7 @@ class Inotify(object):
                 # (fd) looks to always match the inotify FD.
 
                 names = self._get_event_names(event_type)
-                _LOGGER.debug("Events received from epoll: {}".format(names))
+                _LOGGER.debug("Events received from epoll: {0}".format(names))
 
                 for (header, type_names, path, filename) \
                         in self._handle_inotify_event(fd):

--- a/tests/test_inotify.py
+++ b/tests/test_inotify.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import os
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 import inotify.constants
 import inotify.adapters


### PR DESCRIPTION
As there are many installations with only default 2.6 Python in place an no "supported" updates are available in official repos for OS we should try to stay Python 2.6 compatible... (At least all the Redhat/Centos 6 systems are affected.)

Up to now there is "nothing" in PyInotify that is not working with 2.6 and it would be fine if that could last for a while, at least as long enterprise operating systems like Centos/Redhat 6 are supported and offer no official update to Python 2.7.
_I know there are Python 3.4 packages available for these two via epel, but unfortunately in some companies are still policies in place that enforce pyhton 2.6 for commonly used scripts...
And there are companies still having unsupported Centos/Redhat 5 systems in production where the latest version available via epel is 2.6._

* Update .travis.yml
include v2.6 and for that version do the following addtional tasks:
- explicitly install pycparser version 2.18 needed by coverall as this is latest version that's 2.6 compatible
- install unittest2 to have the newer unittest features available for 2.6 so only minimal change required for test_inotify.py
* Update test_inotify.py
import unittest2 as unittest for python version 2.6
* Update adapters.py
change debug code to format syntax understood by 2.6

Drawback of this: the travis test for 2.6 takes quite much time because some dependencies need to be compiled. But I think this is not a big issue.