### PR TITLE
Fix issue #77: InotifyTree doesn't work on re-created directory

### DIFF
--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -299,7 +299,7 @@ class _BaseTree(object):
 
                         self._i.add_watch(full_path, self._mask)
 
-                    if header.mask & inotify.constants.IN_MOVED_FROM:
+                    if header.mask & inotify.constants.IN_DELETE:
                         _LOGGER.debug("A directory has been removed. We're "
                                       "being recursive, but it would have "
                                       "automatically been deregistered: [%s]",

--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -123,7 +123,7 @@ class Inotify(object):
         if superficial is False:
             _LOGGER.debug("Removing watch for watch-handle (%d).", wd)
 
-            inotify.calls.inotify_rm_watch(self.__inotify_fd, wd)
+            # inotify.calls.inotify_rm_watch(self.__inotify_fd, wd)
 
     def _get_event_names(self, event_type):
         names = []


### PR DESCRIPTION
Fix issue #77: InotifyTree doesn't work on re-created directory.
Fix wrong condition when removing a directory by replacing `IN_MOVED_FROM` to `IN_DELETE`.