### PR TITLE
Added setup.cfg option to make bdist_wheel create a universal wheel.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
My project using inotify just upgraded to Python 3. Your documentation states Python 3 compatibility, but the wheel file on PyPI is only targeted at Python 2, leaving installing from the source distribution as the only option for Python 3 developers. 

The simple change here coerces your build script into generating a wheel file that will work for both Python 2 and Python 3. 