### PR TITLE
Improved single file monitoring.

### DIFF
--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -115,7 +115,7 @@ class Inotify(object):
 
         del self.__watches[path]
 
-        self.remove_watch_with_id(wd, superficial)
+        self.remove_watch_with_id(wd)
 
     def remove_watch_with_id(self, wd, superficial=False):
         del self.__watches_r[wd]
@@ -190,7 +190,7 @@ class Inotify(object):
 
     def event_gen(
             self, timeout_s=None, yield_nones=True, filter_predicate=None,
-            terminal_events=_DEFAULT_TERMINAL_EVENTS, handle_in_ignored=False):
+            terminal_events=_DEFAULT_TERMINAL_EVENTS):
         """Yield one event after another. If `timeout_s` is provided, we'll
         break when no event is received for that many seconds.
         """
@@ -230,10 +230,6 @@ class Inotify(object):
                 for (header, type_names, path, filename) \
                         in self._handle_inotify_event(fd):
                     last_hit_s = time.time()
-
-                    if handle_in_ignored and\
-                            header.mask & inotify.constants.IN_IGNORED:
-                        self.remove_watch(path, superficial=True)
 
                     e = (header, type_names, path, filename)
                     for type_name in type_names:

--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -115,7 +115,7 @@ class Inotify(object):
 
         del self.__watches[path]
 
-        self.remove_watch_with_id(wd)
+        self.remove_watch_with_id(wd, superficial)
 
     def remove_watch_with_id(self, wd, superficial=False):
         del self.__watches_r[wd]
@@ -190,7 +190,7 @@ class Inotify(object):
 
     def event_gen(
             self, timeout_s=None, yield_nones=True, filter_predicate=None,
-            terminal_events=_DEFAULT_TERMINAL_EVENTS):
+            terminal_events=_DEFAULT_TERMINAL_EVENTS, handle_in_ignored=False):
         """Yield one event after another. If `timeout_s` is provided, we'll
         break when no event is received for that many seconds.
         """
@@ -230,6 +230,10 @@ class Inotify(object):
                 for (header, type_names, path, filename) \
                         in self._handle_inotify_event(fd):
                     last_hit_s = time.time()
+
+                    if handle_in_ignored and\
+                            header.mask & inotify.constants.IN_IGNORED:
+                        self.remove_watch(path, superficial=True)
 
                     e = (header, type_names, path, filename)
                     for type_name in type_names:

--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -231,6 +231,9 @@ class Inotify(object):
                         in self._handle_inotify_event(fd):
                     last_hit_s = time.time()
 
+                    if header.mask & inotify.constants.IN_IGNORED:
+                        self.remove_watch(path, superficial=True)
+
                     e = (header, type_names, path, filename)
                     for type_name in type_names:
                         if filter_predicate is not None and \


### PR DESCRIPTION
Hi,

I found that the `Inotify` class is not doing a great job in single file monitoring.


According to `man inotify` : 

```
           IN_IGNORED
                  Watch  was removed explicitly (inotify_rm_watch(2)) or auto‐
                  matically (file was deleted, or filesystem  was  unmounted).
```

The event `IN_IGNORED` is generated when a watch has been automatically removed, this happens when the monitored file is removed, and it also happens when user modify the monitored file with text editors that will replace the original file while saving (such as `vim`). 

But the `Inotify` class itself doesn't handle this event, so the consequence is: when this happens, the watch has been automatically removed by the kernel but it still exists in the `Inotify` class (in `Inotify.__watches` and `Inotify.__watches_r`), and this causes a bug, when a monitored file is removed/replaced, users can no long re-add it back into the monitoring, if they try to remove it first by calling `Inotify.remove_watch()` then the system call `inotify_rm_watch()` will return an error because the watch does not exist in the kernel space.

So, the thing I've done is giving users an optional argument to make the `Inotify` class handle the `IN_IGNORED` event and it's disabled by default.

And I changed the usage of `superficial` parameter in `Inotify.remove_watch` as well which was not being used.