### PR TITLE
Add support for BSD's libinotify

### DIFF
--- a/inotify/library.py
+++ b/inotify/library.py
@@ -6,3 +6,8 @@ if _FILEPATH is None:
     _FILEPATH = 'libc.so.6'
 
 instance = ctypes.cdll.LoadLibrary(_FILEPATH)
+if not hasattr(instance, 'inotify_init'):
+    _FILEPATH = ctypes.util.find_library('inotify')
+    if _FILEPATH is None:
+        _FILEPATH = 'libinotify.so.0'
+    instance = ctypes.cdll.LoadLibrary(_FILEPATH)


### PR DESCRIPTION
libinotify emulates linux's inotify interface via a worker thread and kqueue
watches on the files.

The interface is compatible, but we need to change two things:
First, where we find the symbols for inotify, as they are in libinotify and not
in libc.
Second, we can't use epoll, so we instead use kqueue on the watch descriptor.
There are scaling limits on the number of watches as each watched file consumes
a file descriptor, but for many small projects this is sufficient.





I'm welcome to restructure the conditionals if there's a cleaner way. This is just a good start to compatibility.