### PR TITLE
adapters: safely parse DEBUG environment variable

### DIFF
--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -34,7 +34,11 @@ _INOTIFY_EVENT = collections.namedtuple(
                     ])
 
 _STRUCT_HEADER_LENGTH = struct.calcsize(_HEADER_STRUCT_FORMAT)
-_IS_DEBUG = bool(int(os.environ.get('DEBUG', '0')))
+
+try:
+    _IS_DEBUG = bool(int(os.environ.get('DEBUG', '0')))
+except ValueError:
+    _IS_DEBUG = False
 
 
 class EventTimeoutException(Exception):


### PR DESCRIPTION
Parse the value of the DEBUG environment variable defensively, to guard against breaking processes where the inotify package is imported but the value of DEBUG is not guaranteed to be an integer (e.g. as part of `gunicorn --reload`).

Without this change, running

```
DEBUG=true gunicorn --reload app
```

will fail with a stack trace like so:

```
Traceback (most recent call last):
  File "/usr/local/bin/gunicorn", line 5, in <module>
    from gunicorn.app.wsgiapp import run
  File "/usr/local/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 9, in <module>
    from gunicorn.app.base import Application
  File "/usr/local/lib/python3.8/site-packages/gunicorn/app/base.py", line 13, in <module>
    from gunicorn.config import Config, get_default_config_file
  File "/usr/local/lib/python3.8/site-packages/gunicorn/config.py", line 22, in <module>
    from gunicorn.reloader import reloader_engines
  File "/usr/local/lib/python3.8/site-packages/gunicorn/reloader.py", line 59, in <module>
    from inotify.adapters import Inotify
  File "/usr/local/lib/python3.8/site-packages/inotify/adapters.py", line 37, in <module>
    _IS_DEBUG = bool(int(os.environ.get('DEBUG', '0')))
ValueError: invalid literal for int() with base 10: 'true'
```