### PR TITLE
Use sudo -H to avoid change permissions

### DIFF
--- a/inotify/resources/README.rst
+++ b/inotify/resources/README.rst
@@ -18,7 +18,7 @@ Installing
 
 Install via *pip*::
 
-    $ sudo pip install inotify
+    $ sudo -H pip install inotify
 
 
 =======


### PR DESCRIPTION
Use sudo -H to avoid change permissions on ~/.cache/pip of the non-root user