### PR TITLE
safely parse DEBUG environment variable

### DIFF
--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -4,6 +4,7 @@ import os
 import struct
 import collections
 import time
+from distutils.util import strtobool
 
 from errno import EINTR
 
@@ -34,7 +35,15 @@ _INOTIFY_EVENT = collections.namedtuple(
                     ])
 
 _STRUCT_HEADER_LENGTH = struct.calcsize(_HEADER_STRUCT_FORMAT)
-_IS_DEBUG = bool(int(os.environ.get('DEBUG', '0')))
+
+def _cast_boolean(value):
+    """
+    Helper to convert config values to boolean as ConfigParser do.
+    """
+    value = str(value)
+    return bool(value) if value == '' else bool(strtobool(value))
+
+_IS_DEBUG = _cast_boolean(os.environ.get('DEBUG', '0'))
 
 
 class EventTimeoutException(Exception):


### PR DESCRIPTION
This pull request adds a safer way to parse the `DEBUG` environment variable.

Instead of only support integers to represent a boolean value, now its supports:

True values are `y`, `yes`, `t`, `true`, `on`, and `1`; 
False values are `n`, `no`, `f`, `false`, `off`, `0` and empty string.
Raises `ValueError` if is anything else.

https://github.com/python/cpython/blob/3.9/Lib/distutils/util.py#L307-L320
