### PR TITLE
Capture errno properly in C library calls; don't crash when a directory disappears before we can list/watch it

### DIFF
--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -352,7 +352,7 @@ class InotifyTree(_BaseTree):
             try:
                 filenames = os.listdir(current_path)
             except FileNotFoundError:
-                _LOGGER.debug("Path %s disappeared before we could list it", current_path)
+                _LOGGER.warning("Path %s disappeared before we could list it", current_path)
                 continue
                 
             paths.append(current_path)
@@ -369,7 +369,7 @@ class InotifyTree(_BaseTree):
                 self._i.add_watch(path, self._mask)
             except inotify.calls.InotifyError as e:
                 if e.errno == ENOENT:
-                    _LOGGER.debug("Path %s disappeared before we could watch it", path)
+                    _LOGGER.warning("Path %s disappeared before we could watch it", path)
                     continue
                 raise                
 


### PR DESCRIPTION
Fixes #112, #113

Test program for #113:

```python
#!/usr/bin/env python3

import inotify.adapters
import logging
import os
import shutil
import sys
import threading

td = '/tmp/inotify-test'
nf = 1000

def make_td():
    shutil.rmtree(td, ignore_errors=True)
    os.mkdir(td)
    for i in range(nf):
        os.mkdir(f'{td}/{i}')


def watch_tree():
    inotify.adapters.InotifyTree(td)


logger = logging.getLogger(None)
logger.setLevel(logging.DEBUG)
handler = logging.StreamHandler(sys.stderr)
logger.addHandler(handler)

make_td()
thread = threading.Thread(target=watch_tree, daemon=True)
thread.start()
for i in range(nf):
    os.rmdir(f'{td}/{i}')
thread.join()
```

You may need to increase the number of directories (`nf` in the code) if you're running it on an SSD rather than an HDD.