### PR TITLE
Use a valid SPDX identifier as license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     author='Dustin Oprea',
     author_email='myselfasunder@gmail.com',
     url='https://github.com/dsoprea/PyInotify',
-    license='GPL 2',
+    license='GPL-2.0-only',
     packages=setuptools.find_packages(exclude=['tests']),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
This helps automatic license checkers like pip-licenses to identify the right license for this project