### PR TITLE
Don't crash on ENOENT when adding watch inside event_gen

### DIFF
--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -318,8 +318,13 @@ class _BaseTree(object):
                         _LOGGER.debug("A directory has been renamed. We're "
                                       "adding a watch on it (because we're "
                                       "being recursive): [%s]", full_path)
-
-                        self._i.add_watch(full_path, self._mask)
+                        try:
+                            self._i.add_watch(full_path, self._mask)
+                        except inotify.calls.InotifyError as e:
+                            if e.errno == ENOENT:
+                                _LOGGER.warning("Path %s disappeared before we could watch it", full_path)
+                            else:
+                                raise
 
             yield event
 


### PR DESCRIPTION
If we get an event notification about a directory being moved and then it disappears before we have time to add a watch to it, we need to catch the resulting ENOENT error and warn about it rather than crashing.

This is similar to the fix made in
ef6769dda4c7f1396cea5f8c5a5530b23b81558f.

N.B. there are now two additional bug fixes here on my master branch in addition to the one described above for which I originally opened this PR.